### PR TITLE
CI matrix append Node.js v17

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -41,8 +41,11 @@ jobs:
         timeout-minutes: 2
         if: matrix.node < 17
 
-      - if: matrix.node >= 17
-        run: NODE_OPTIONS=--openssl-legacy-provider npm run test -- --coverage --verbose
+      - run: NO_SKIP=on npm run test -- --coverage --verbose
+        timeout-minutes: 2
+        if: matrix.node >= 17
+        env:
+          NODE_OPTIONS: --openssl-legacy-provider
 
       - name: Smoking build
         run: |-

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        node: [ '12', '14', '16' ]
+        node: [ '12', '14', '16', '17' ]
 
     steps:
 
@@ -39,6 +39,10 @@ jobs:
 
       - run: NO_SKIP=on npm run test -- --coverage --verbose
         timeout-minutes: 2
+        if: matrix.node < 17
+
+      - if: matrix.node >= 17
+        run: NODE_OPTIONS=--openssl-legacy-provider npm run test -- --coverage --verbose
 
       - name: Smoking build
         run: |-


### PR DESCRIPTION
Getting runtime error in _v17_

    error:0308010C:digital envelope routines::unsupported

This change revives upcoming breaking changes in **Node.js** _v18_, caused by its internal **OpenSSL** _v3_ upgrade, specifically the `rc4` related encryption methods.

Could use `NODE_OPTIONS=--openssl-legacy-provider` to temporarily mitigate the issue[^1].

[^1]: https://nodejs.org/en/blog/release/v17.0.0/#openssl-3-0



