### PR TITLE
es2015 in exportConditions for rollup/node-resolve

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -64,7 +64,9 @@ export default defineConfig({
     },
 
     plugins: [
-        resolve(),
+        resolve({
+            exportConditions: [ 'es2015' ],
+        }),
         commonjs({
             include: [
                 'node_modules/**'


### PR DESCRIPTION
### before
`69.62 KB` - `rxjs/dist/esm5/internal`

### after
`56.94 KB` - `rxjs/dist/esm/internal`